### PR TITLE
Add TOKEN_PREFIX to secure_token

### DIFF
--- a/activerecord/lib/active_record/secure_token.rb
+++ b/activerecord/lib/active_record/secure_token.rb
@@ -33,7 +33,8 @@ module ActiveRecord
       end
 
       def generate_unique_secure_token
-        SecureRandom.base58(24)
+        prefix = self.const_get(:TOKEN_PREFIX) if self.constants.include? :TOKEN_PREFIX
+        "#{prefix}#{SecureRandom.base58(24)}"
       end
     end
   end

--- a/activerecord/test/cases/secure_token_test.rb
+++ b/activerecord/test/cases/secure_token_test.rb
@@ -31,4 +31,12 @@ class SecureTokenTest < ActiveRecord::TestCase
 
     assert_equal "custom-secure-token", @user.token
   end
+
+  def test_token_prefix
+    User.const_set(:TOKEN_PREFIX, "user_")
+
+    @user.save
+
+    assert_match %r{^user_.+}, @user.token
+  end
 end


### PR DESCRIPTION
### Summary

Adding TOKEN_PREFIX to secure_token so that it's easier to determine which tokens belong to which objects